### PR TITLE
Dogcount

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "build-dev": "env-cmd -e development npm run-script build",
     "build-stage": "env-cmd -e staging npm run-script build",
     "build-prod": "env-cmd -e production npm run-script build",
-    "heroku-postbuild": "npm run-script build-prod",
+    "heroku-postbuild": "npm run-script build-stage",
     "eject": "react-scripts eject",
     "clean": "rm -rf node_modules"
   },

--- a/server/routes/mobile.router.js
+++ b/server/routes/mobile.router.js
@@ -23,10 +23,13 @@ const getDailyDogsSearchQuery = (day) => {
     const weekdayNumber = day.getDay();
     // SQL to grab dogs scheduled for given weekday
     let searchQuery;
-    if ( 0 < weekdayNumber < 6) {
+    if ( weekdayNumber === 0 || weekdayNumber === 6) {
+        console.log('hi')
+        searchQuery = `SELECT NULL AS dogs;`;
+    } else {
         searchQuery = `
         SELECT clients_schedule.id,
-            clients_schedule."1" AS Monday , 
+            clients_schedule."1" AS Monday ,    
             clients_schedule."2" AS Tuesday,
             clients_schedule."3" AS Wednesday,
             clients_schedule."4" AS Thursday, 
@@ -50,9 +53,8 @@ const getDailyDogsSearchQuery = (day) => {
             route_id,
             client_id;
         `;
-    } else {
-        searchQuery = `SELECT NULL AS result;`
     }
+    
         
         // SQL to grab schedule adjustments table
     const scheduleQuery = `
@@ -219,7 +221,8 @@ router.get('/checkDogSchedule/:date', async (req, res) => {
         const scheduleAdjustments = scheduleAdjustmentsResponse.rows;
 
         if (scheduleAdjustments < 1 ) {
-            const dogsScheduledForDay = fillScheduled(scheduledDogs)
+            const dogsScheduledForDay = fillScheduled(scheduledDogs);
+            // console.log(dogsScheduledForDay[0].dogs)
             res.send({dogsScheduledForDay});
         } else {
             const adjustedDogs = getAdjustedSchedule(scheduledDogs,scheduleAdjustments)

--- a/server/routes/mobile.router.js
+++ b/server/routes/mobile.router.js
@@ -21,14 +21,33 @@ const {
 const getDailyDogsSearchQuery = (day) => {
 
     const weekdayNumber = day.getDay();
-
     // SQL to grab dogs scheduled for given weekday
     let searchQuery = `
-    SELECT clients_schedule.id, clients_schedule."1" AS Monday,  clients_schedule."2" AS Tuesday,  clients_schedule."3" AS Wednesday,  clients_schedule."4" AS Thursday,  clients_schedule."5" AS Friday, dogs.client_id, clients.route_id, clients.first_name, clients.last_name, dogs."name", routes."name" AS route_name, dogs.id AS dog_id from clients_schedule
+    SELECT clients_schedule.id, 
+        CASE WHEN ${weekdayNumber} BETWEEN 1 AND 5 THEN clients_schedule."1" ELSE NULL END AS Monday,  
+        CASE WHEN ${weekdayNumber} BETWEEN 1 AND 5 THEN clients_schedule."2" ELSE NULL END AS Tuesday,  
+        CASE WHEN ${weekdayNumber} BETWEEN 1 AND 5 THEN clients_schedule."3" ELSE NULL END AS Wednesday,  
+        CASE WHEN ${weekdayNumber} BETWEEN 1 AND 5 THEN clients_schedule."4" ELSE NULL END AS Thursday,  
+        CASE WHEN ${weekdayNumber} BETWEEN 1 AND 5 THEN clients_schedule."5" ELSE NULL END AS Friday, 
+        dogs.client_id,
+        clients.route_id,
+        clients.first_name,
+        clients.last_name, 
+        dogs."name",
+        routes."name" AS route_name,
+        dogs.id AS dog_id
+    FROM 
+        clients_schedule
         JOIN "dogs" ON clients_schedule.client_id = dogs.client_id
         JOIN "clients" ON clients_schedule.client_id = clients.id
         JOIN "routes" ON clients.route_id = routes.id
-        WHERE "${weekdayNumber}" = TRUE AND dogs.active = TRUE AND dogs.regular = TRUE ORDER BY route_id, client_id;
+    WHERE
+        ${weekdayNumber} BETWEEN 1 AND 5
+        AND dogs.active = TRUE
+        AND dogs.regular = TRUE
+    ORDER BY 
+        route_id,
+        client_id;
     `;
 
     // SQL to grab schedule adjustments table
@@ -188,20 +207,22 @@ router.get('/checkDogSchedule/:date', async (req, res) => {
         // scheduled dogs is an array of objects - of the dogs originally scheduled for the day.
         // find the dogs default scheduled for the day
         const scheduledDogsResponse = await client.query(searchQuery);
+
         const scheduledDogs = scheduledDogsResponse.rows;
     
         // find the schedule changes for the day
         const scheduleAdjustmentsResponse = await client.query(scheduleQuery,[date]);
         const scheduleAdjustments = scheduleAdjustmentsResponse.rows;
 
-    
+        if (!scheduledDogs) {
+            console.log('no dogs')
+        }
         if (scheduleAdjustments < 1 ) {
             const dogsScheduledForDay = fillScheduled(scheduledDogs)
             res.send({dogsScheduledForDay});
         } else {
             const adjustedDogs = getAdjustedSchedule(scheduledDogs,scheduleAdjustments)
             dogsScheduledForDay = fillScheduled(adjustedDogs);
-
             res.send({dogsScheduledForDay});
         }
     } catch (error) {

--- a/server/routes/mobile.router.js
+++ b/server/routes/mobile.router.js
@@ -4,8 +4,6 @@ const router = express.Router();
 const {
     rejectUnauthenticated,
 } = require('../modules/authentication-middleware');
-const { Day } = require('react-big-calendar');
-
 
 // ADMIN ONLY:
 // /daily for generating daily dogs
@@ -17,8 +15,8 @@ const { Day } = require('react-big-calendar');
 // /route/:route_id for GETTING specific route / dog info
 // /dog/:id for GETTING a specific dogs details
 
-// GET ROUTE FOR DAILY DOGS SCHEDULE
 
+// FUNCTIONS SHARED BY ROUTES
 // getDailyDogsSearchQuery generates search query that is used by both /mobile/daily and /mobile/checkDogsSchedule endpoints
 const getDailyDogsSearchQuery = (day) => {
 
@@ -26,9 +24,10 @@ const getDailyDogsSearchQuery = (day) => {
 
     // SQL to grab dogs scheduled for given weekday
     let searchQuery = `
-    SELECT clients_schedule.id, clients_schedule."1" AS Monday,  clients_schedule."2" AS Tuesday,  clients_schedule."3" AS Wednesday,  clients_schedule."4" AS Thursday,  clients_schedule."5" AS Friday, dogs.client_id, clients.route_id, dogs.name, dogs.id AS dog_id from clients_schedule
+    SELECT clients_schedule.id, clients_schedule."1" AS Monday,  clients_schedule."2" AS Tuesday,  clients_schedule."3" AS Wednesday,  clients_schedule."4" AS Thursday,  clients_schedule."5" AS Friday, dogs.client_id, clients.route_id, clients.first_name, clients.last_name, dogs."name", routes."name" AS route_name, dogs.id AS dog_id from clients_schedule
         JOIN "dogs" ON clients_schedule.client_id = dogs.client_id
         JOIN "clients" ON clients_schedule.client_id = clients.id
+        JOIN "routes" ON clients.route_id = routes.id
         WHERE "${weekdayNumber}" = TRUE AND dogs.active = TRUE AND dogs.regular = TRUE ORDER BY route_id, client_id;
     `;
 
@@ -65,6 +64,8 @@ const getAdjustedSchedule = (scheduledDogs, scheduleAdjustments) => {
     }
     return adjustedDogs;
 }
+
+// GET ROUTE FOR DAILY DOGS SCHEDULE
 
 router.get('/daily', async (req, res) => {
     const client = await pool.connect();
@@ -142,6 +143,47 @@ router.get('/checkDogSchedule/:date', async (req, res) => {
     // console.log('date is', date);
     const [ searchQuery, scheduleQuery ] = getDailyDogsSearchQuery(date);
 
+    // fillScheduled organizes query response by client.
+    const fillScheduled = (dogArray) => {
+        let dogList = dogArray.map(dog => ({
+            dog_id: dog.dog_id,
+            client_id: dog.client_id,
+            name: dog.name,
+            id: dog.id,
+            route_id: dog.route_id,
+            client_first_name: dog.first_name,
+            client_last_name: dog.last_name,
+            route_name: dog.route_name
+        }));
+        
+        let idArray = dogArray.map(dog => dog.client_id);
+
+        //this filters out duplicate IDs
+        let uniqueIds = [...new Set(idArray)]
+
+        //this groups result.rows by id
+        const group = dogList.reduce((acc, item) => {
+            // console.log(acc)
+            if (!acc[item.client_id]) {
+                acc[item.client_id] = [];
+            }
+            acc[item.client_id].push(item);
+            return acc;
+        }, {})
+
+        let clients = uniqueIds.map(clientId => {
+            let dogsForClient = group[clientId];
+        
+            const { client_last_name, client_first_name, route_id, route_name } = dogsForClient[0];
+            const client = { client_last_name, client_first_name, client_id: clientId, route_id, route_name };
+        
+            client.dogs = dogsForClient.map(({ name, id }) => ({ name, id }));
+            
+            return client;
+        });
+        return clients;
+    }
+    
     try {
         // scheduled dogs is an array of objects - of the dogs originally scheduled for the day.
         // find the dogs default scheduled for the day
@@ -151,21 +193,22 @@ router.get('/checkDogSchedule/:date', async (req, res) => {
         // find the schedule changes for the day
         const scheduleAdjustmentsResponse = await client.query(scheduleQuery,[date]);
         const scheduleAdjustments = scheduleAdjustmentsResponse.rows;
+
     
         if (scheduleAdjustments < 1 ) {
-            const dogsScheduledForDay = scheduledDogs.length;
-            // console.log('no adjust: ', dogsScheduledForDay)
+            const dogsScheduledForDay = fillScheduled(scheduledDogs)
             res.send({dogsScheduledForDay});
         } else {
             const adjustedDogs = getAdjustedSchedule(scheduledDogs,scheduleAdjustments)
-            const dogsScheduledForDay = adjustedDogs.length;
-            // console.log('adjust: ', dogsScheduledForDay)
+            dogsScheduledForDay = fillScheduled(adjustedDogs);
+
             res.send({dogsScheduledForDay});
         }
     } catch (error) {
         console.log('error checking scheduled dogs', error.detail);
         res.sendStatus(500);
     } finally {
+        console.log('release')
         client.release();
     }
 });

--- a/server/routes/mobile.router.js
+++ b/server/routes/mobile.router.js
@@ -162,7 +162,7 @@ router.get('/daily', async (req, res) => {
 
 // router returns number of dogs scheduled for given day
 router.get('/checkDogSchedule/:date', async (req, res) => {
-    console.log('in /checkDogSchedule', req.params.date)
+    // console.log('in /checkDogSchedule', req.params.date)
     const client = await pool.connect();
     const date = new Date(req.params.date);
     // console.log('date is', date);
@@ -233,7 +233,6 @@ router.get('/checkDogSchedule/:date', async (req, res) => {
         console.log('error checking scheduled dogs', error.detail);
         res.sendStatus(500);
     } finally {
-        console.log('release')
         client.release();
     }
 });

--- a/src/components/Desktop/Desktop.css
+++ b/src/components/Desktop/Desktop.css
@@ -2,7 +2,7 @@
     height: 150%;
     background-image: url('https://img.freepik.com/free-vector/digital-technology-background-with-abstract-wave-border_53876-117508.jpg?w=1800&t=st=1667757157~exp=1667757757~hmac=8e0fdfc65e72c2cc5430d8585ea5e091b5d888ba84d8a1dde5cdc32b4a251f8b');
     background-size: cover;
-    background-color: #504f4e;
+    background-color: #e4e4e4;
 }
 
 .dogPhoto{

--- a/src/components/Desktop/SplashPage/DogCount.jsx
+++ b/src/components/Desktop/SplashPage/DogCount.jsx
@@ -24,7 +24,9 @@ function DogCount() {
 
   const [date, setDate] = useState(today);
   const scheduledDogs = useSelector(store => store.scheduledDogs);
-  // kinda screwy here; if page opens on weekend, response object is single client with undefined fields. returns count 0 if dog id = undefined.
+  // kinda screwy here; if page opens on weekend, response object is single client with undefined fields.
+  // returns count 0 if dog id = undefined.
+  // this edge case is also addressed for mapping in line 77.
   const dogCount = scheduledDogs[0] ? scheduledDogs.reduce((acc, obj) => {
       if (obj.dogs[0].id === undefined) {
         return 0;

--- a/src/components/Desktop/SplashPage/DogCount.jsx
+++ b/src/components/Desktop/SplashPage/DogCount.jsx
@@ -23,7 +23,11 @@ function DogCount() {
   let today = new Date().toISOString();
 
   const [date, setDate] = useState(today);
-  const dogCount = useSelector(store => store.scheduledDogs);
+  const scheduledDogs = useSelector(store => store.scheduledDogs);
+  const dogCount = scheduledDogs[0] ? scheduledDogs.reduce((acc, obj) => {
+      return acc + obj.dogs.length;
+    }, 0) : 0;
+
   useEffect(() => {
     handleDateChange(today);
   }, []);
@@ -40,9 +44,9 @@ function DogCount() {
   };
 
   return (
-    <Grid item xs={4}>
-      <Card sx={{mx: 5, display: "flex", flexDirection: "column", alignItems:"center"}}>
-        {/* <Typography sx={{mt: 1}}> Dogs scheduled for {dayjs(date).format('MM/DD')}: <b>{dogCount}</b> </Typography> */}
+    <Grid item xs={6} >
+      <Card sx={{mx: 5, mb: 5, display: "flex", flexDirection: "column", alignItems:"center", maxHeight: "75vh" }}>
+        <Typography sx={{mt: 1}}> Dogs scheduled for {dayjs(date).format('MM/DD')}: <b>{dogCount}</b> </Typography>
         <LocalizationProvider dateAdapter={AdapterDayjs}>
           <DatePicker
             shouldDisableDate={isWeekend}
@@ -53,22 +57,22 @@ function DogCount() {
             }}
           />
         </LocalizationProvider>
-        <TableContainer component={Paper}>
-          <Table stickyHeader size="small">
+        <TableContainer component={Paper} >
+          <Table stickyHeader size="small" sx={{overflow:'auto'}}>
             <TableHead>
               <TableRow>
                   <TableCell sx={{fontWeight: '800'}}>Client:</TableCell>
-                  <TableCell sx={{fontWeight: '800'}}>Client:</TableCell>
+                  <TableCell sx={{fontWeight: '800'}}>Route:</TableCell>
                   <TableCell sx={{fontWeight: '800'}}>Dogs:</TableCell>
                 <TableCell></TableCell>
               </TableRow>
             </TableHead>
-            <TableBody>
-            {dogCount && dogCount[0] && dogCount.map((dog) => (
+            <TableBody >
+            {scheduledDogs && scheduledDogs[0] && scheduledDogs.map((dog) => (
               <StyledTableRow key={dog.client_id}> 
-                <TableCell >{dog.client_first_name}, {dog.client_last_name}</TableCell>
+                <TableCell >{dog.client_last_name}, {dog.client_first_name}</TableCell>
                 <TableCell >{dog.route_name}</TableCell>
-                <TableCell >{dog.dogs.map(d => (d.name + ' '))}</TableCell>
+                <TableCell >{dog.dogs.map(d => (d.name + ', '))}</TableCell>
               </StyledTableRow>
             ))}
             </TableBody>

--- a/src/components/Desktop/SplashPage/DogCount.jsx
+++ b/src/components/Desktop/SplashPage/DogCount.jsx
@@ -1,0 +1,82 @@
+// imports
+
+import { useSelector, useDispatch } from 'react-redux';
+import { useState, useEffect} from 'react';
+import dayjs from 'dayjs';
+
+// MUI
+import { Table, TableContainer, TableHead, Paper, TableBody, TableRow, TableCell, Grid, Typography, Card, TextField } from '@mui/material';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { styled } from '@mui/system';
+
+// CUSTOM COMPONENTS FOR SEARCH RESULTS
+const StyledTableRow = styled(TableRow)(({ theme }) => ({
+  '&.MuiTableRow-root:hover':{
+    backgroundColor: '#accad5' ,
+  },
+}));
+
+function DogCount() {
+  const dispatch = useDispatch();
+  let today = new Date().toISOString();
+
+  const [date, setDate] = useState(today);
+  const dogCount = useSelector(store => store.scheduledDogs);
+  useEffect(() => {
+    handleDateChange(today);
+  }, []);
+
+  const handleDateChange = (date) => {
+    setDate(date);
+    dispatch({ type: 'CHECK_DOG_SCHEDULES', payload: dayjs(date).format('YYYY-MM-DD') });
+  }
+
+  const isWeekend = (date) => {
+    const day = date.day();
+  
+    return day === 0 || day === 6;
+  };
+
+  return (
+    <Grid item xs={4}>
+      <Card sx={{mx: 5, display: "flex", flexDirection: "column", alignItems:"center"}}>
+        {/* <Typography sx={{mt: 1}}> Dogs scheduled for {dayjs(date).format('MM/DD')}: <b>{dogCount}</b> </Typography> */}
+        <LocalizationProvider dateAdapter={AdapterDayjs}>
+          <DatePicker
+            shouldDisableDate={isWeekend}
+            onChange={handleDateChange}
+            value={date}
+            renderInput={(params) => {
+              return <TextField {...params} sx={{ mt: 2 ,mx: 2, pb: 1, width: '15vw' }} />
+            }}
+          />
+        </LocalizationProvider>
+        <TableContainer component={Paper}>
+          <Table stickyHeader size="small">
+            <TableHead>
+              <TableRow>
+                  <TableCell sx={{fontWeight: '800'}}>Client:</TableCell>
+                  <TableCell sx={{fontWeight: '800'}}>Client:</TableCell>
+                  <TableCell sx={{fontWeight: '800'}}>Dogs:</TableCell>
+                <TableCell></TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+            {dogCount && dogCount[0] && dogCount.map((dog) => (
+              <StyledTableRow key={dog.client_id}> 
+                <TableCell >{dog.client_first_name}, {dog.client_last_name}</TableCell>
+                <TableCell >{dog.route_name}</TableCell>
+                <TableCell >{dog.dogs.map(d => (d.name + ' '))}</TableCell>
+              </StyledTableRow>
+            ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Card >
+    </Grid>
+  )
+}
+
+export default DogCount;

--- a/src/components/Desktop/SplashPage/DogCount.jsx
+++ b/src/components/Desktop/SplashPage/DogCount.jsx
@@ -24,7 +24,11 @@ function DogCount() {
 
   const [date, setDate] = useState(today);
   const scheduledDogs = useSelector(store => store.scheduledDogs);
+  // kinda screwy here; if page opens on weekend, response object is single client with undefined fields. returns count 0 if dog id = undefined.
   const dogCount = scheduledDogs[0] ? scheduledDogs.reduce((acc, obj) => {
+      if (obj.dogs[0].id === undefined) {
+        return 0;
+      }
       return acc + obj.dogs.length;
     }, 0) : 0;
 
@@ -68,7 +72,7 @@ function DogCount() {
               </TableRow>
             </TableHead>
             <TableBody >
-            {scheduledDogs && scheduledDogs[0] && scheduledDogs.map((dog) => (
+            {scheduledDogs && scheduledDogs[0] && scheduledDogs[0].dogs[0].id != undefined && scheduledDogs.map((dog) => (
               <StyledTableRow key={dog.client_id}> 
                 <TableCell >{dog.client_last_name}, {dog.client_first_name}</TableCell>
                 <TableCell >{dog.route_name}</TableCell>

--- a/src/components/Desktop/SplashPage/SplashPage.jsx
+++ b/src/components/Desktop/SplashPage/SplashPage.jsx
@@ -10,7 +10,7 @@ import DogCount from './DogCount';
 import './SplashPage.css';
 
 //MUI
-import { Box, Grid, Typography, Card, TextField, CardActionArea, CardMedia, CardContent } from '@mui/material';
+import { Box, Grid, Card, CardMedia, CardContent } from '@mui/material';
 
 function SplashPage() {
 
@@ -18,7 +18,7 @@ function SplashPage() {
 
   return (
     <Box className="splash_container" sx={{width: '100%', height: '80vh'}}>
-      <Grid container spacing={2} sx={{ alignItems: "center", display: "flex", pl: '5vw', mt: 5}}>
+      <Grid container spacing={2} sx={{ alignItems: "start", display: "flex", pl: '5vw', mt: 2}}>
         <Grid item xs={6}>
           <Card sx={{ pb: 2, mb: 5 }}>
             {/* <CardActionArea> */}
@@ -28,14 +28,13 @@ function SplashPage() {
                 image="https://static.vecteezy.com/system/resources/thumbnails/000/210/848/small_2x/abstract-border-collie-dog-portrait-in-low-poly-vector-design.jpg"
                 alt="dog with glasses on"
               />
-              <CardContent sx={{ justifyContent: "stretch", alignItems: "center", height: '100%' }}>
+              <CardContent sx={{ justifyContent: "stretch", alignItems: "center", height: '90%' }}>
               </CardContent>
             {/* </CardActionArea> */}
             {user.id ?
               <AdminNotes  /> : null}
           </Card>
         </Grid>
-        <Grid item xs={1}/>
         <DogCount />
         </Grid>
     </Box>

--- a/src/components/Desktop/SplashPage/SplashPage.jsx
+++ b/src/components/Desktop/SplashPage/SplashPage.jsx
@@ -6,36 +6,15 @@ import dayjs from 'dayjs';
 
 // components
 import AdminNotes from '../AdminNotes/AdminNotes';
+import DogCount from './DogCount';
 import './SplashPage.css';
 
 //MUI
 import { Box, Grid, Typography, Card, TextField, CardActionArea, CardMedia, CardContent } from '@mui/material';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 
 function SplashPage() {
 
-  const dispatch = useDispatch();
-  let today = new Date().toISOString();
-
   const user = useSelector((store) => store.user);
-  const [date, setDate] = useState(today);
-  const dogCount = useSelector(store => store.scheduledDogs);
-  useEffect(() => {
-    handleDateChange(today);
-  }, []);
-
-  const handleDateChange = (date) => {
-    setDate(date);
-    dispatch({ type: 'CHECK_DOG_SCHEDULES', payload: dayjs(date).format('YYYY-MM-DD') });
-  }
-
-  const isWeekend = (date) => {
-    const day = date.day();
-  
-    return day === 0 || day === 6;
-  };
 
   return (
     <Box className="splash_container" sx={{width: '100%', height: '80vh'}}>
@@ -57,22 +36,8 @@ function SplashPage() {
           </Card>
         </Grid>
         <Grid item xs={1}/>
-        <Grid item xs={4}>
-          <Card sx={{mx: 5, display: "flex", flexDirection: "column", alignItems:"center"}}>
-            <Typography sx={{mt: 1}}> Dogs scheduled for {dayjs(date).format('MM/DD')}: <b>{dogCount}</b> </Typography>
-            <LocalizationProvider dateAdapter={AdapterDayjs}>
-              <DatePicker
-                shouldDisableDate={isWeekend}
-                onChange={handleDateChange}
-                value={date}
-                renderInput={(params) => {
-                  return <TextField {...params} sx={{ mt: 2 ,mx: 2, pb: 1, width: '15vw' }} />
-                }}
-              />
-            </LocalizationProvider>
-          </Card >
+        <DogCount />
         </Grid>
-      </Grid>
     </Box>
   );
 }

--- a/src/redux/reducers/scheduledDogs.reducer.js
+++ b/src/redux/reducers/scheduledDogs.reducer.js
@@ -1,7 +1,6 @@
 const scheduledDogs = (state = {}, action) => {
   switch (action.type) {
     case 'DOGS_SCHEDULE_COUNT':
-      console.log('in reducer', action.payload)
       return action.payload;
       default:
         return state;

--- a/src/redux/reducers/scheduledDogs.reducer.js
+++ b/src/redux/reducers/scheduledDogs.reducer.js
@@ -1,4 +1,4 @@
-const scheduledDogs = (state = '', action) => {
+const scheduledDogs = (state = {}, action) => {
   switch (action.type) {
     case 'DOGS_SCHEDULE_COUNT':
       console.log('in reducer', action.payload)

--- a/src/redux/sagas/routes.saga.js
+++ b/src/redux/sagas/routes.saga.js
@@ -248,7 +248,7 @@ function* checkDogSchedules(action){
             method: 'GET',
             url: `/api/mobile/checkDogSchedule/${date}`,
         });
-        console.log(dogsScheduled.data.dogsScheduledForDay);
+        // console.log(dogsScheduled.data.dogsScheduledForDay);
         yield put ({
             type: 'DOGS_SCHEDULE_COUNT',
             payload: dogsScheduled.data.dogsScheduledForDay


### PR DESCRIPTION
Adds feature to admin Desktop view: displays a table of dogs scheduled on a given day, and a total count for that day.

## Overview
- Feature is DogCount.jsx component; child component to SplashPage.jsx.
- DogCount dispatches GET request to api/mobile/checkDogSchedule/:date in router.mobile.js using selected date as url param.  (DogCount.jsx --> routes.saga.js --> router.mobile.js)
- response object is dispatched to scheduledDogs.reducer.js.
- DogCount subscribes to scheduledDogs reducer.
- DogCount dispatches GET request for today's date on page load in useEffect().
- DogCount.jsx lines 27-35: weird handling of an edge case where component is opened on weekend; code notes explain.

## mobile.router.js
- scheduled dog request handled in GET /checkDogSchedule route, using date as param.
- broke out two functions from the GET /daily route to share with GET/checkDogSchedule: SQL Query + get adjusted dog schedule.
#### getDailyDogSearchQuery():
- I added certain fields needed by DogCount.jsx that were not needed for dailydogs.
- formatted query for readability
- logic to handle weekend queries (lines 26-28)
#### getAdjustedSchedule():
- no change to function
- #### GET /checkDogSchedule/:date
- pulled code from clients.router.js to reformat data into array of client objects with dogs array as one field [ {client: client, dogs: [ dog1, dog2]}...]
- simplified object handling using map functions.
