### PR TITLE
Dogcount

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "build-dev": "env-cmd -e development npm run-script build",
     "build-stage": "env-cmd -e staging npm run-script build",
     "build-prod": "env-cmd -e production npm run-script build",
-    "heroku-postbuild": "npm run-script build-stage",
+    "heroku-postbuild": "npm run-script build-prod",
     "eject": "react-scripts eject",
     "clean": "rm -rf node_modules"
   },

--- a/src/components/AllPages/SearchResults/ResultsAllDogs.jsx
+++ b/src/components/AllPages/SearchResults/ResultsAllDogs.jsx
@@ -39,7 +39,8 @@ export default function ResultsAllDogs({clientList, dogList, openModal, view}) {
     {dogList.map((dog) => (
       <StyledTableRow key={dog.dog_id}> 
         <TableCell onClick={()=>getDogDetails(dog)}>{dog.dog_name}</TableCell>
-        <TableCell onClick={()=>getDogDetails(dog)}>{dog.client_firstname} {dog.client_lastname}</TableCell>
+        <TableCell onClick={()=>getDogDetails(dog)}>{dog.client_lastname}, {dog.client_firstname}</TableCell>
+        <TableCell>{dog.route}</TableCell>
         { view==='desktop' ?
         <>
           <TableCell onClick={()=>getDogDetails(dog)}> {dog.days.join(', ').toUpperCase()} </TableCell>

--- a/src/components/AllPages/SearchResults/ResultsDogByDay.jsx
+++ b/src/components/AllPages/SearchResults/ResultsDogByDay.jsx
@@ -38,7 +38,8 @@ export default function ResultsDogByDay({dogList, clientList,openModal, weekSear
       {dogList.filter((dog)=> dog[weekSearch]).map((dog) => (
         <StyledTableRow key={dog.dog_id}> 
           <TableCell onClick={()=>getDogDetails(dog)}>{dog.dog_name}</TableCell>
-          <TableCell onClick={()=>getDogDetails(dog)}>{dog.client_firstname} {dog.client_lastname}</TableCell>
+          <TableCell onClick={()=>getDogDetails(dog)}>{dog.client_lastname}, {dog.client_firstname}</TableCell>
+          <TableCell>{dog.route}</TableCell>
           { view==='desktop' ?
           <>
             <TableCell onClick={()=>getDogDetails(dog)}> {dog.days.join(', ').toUpperCase()} </TableCell>

--- a/src/components/AllPages/SearchResults/ResultsScheduledDogs.jsx
+++ b/src/components/AllPages/SearchResults/ResultsScheduledDogs.jsx
@@ -1,0 +1,25 @@
+import { TableBody, TableRow, TableCell } from '@mui/material';
+import { styled } from '@mui/system';
+
+// CUSTOM COMPONENTS FOR SEARCH RESULTS
+const StyledTableRow = styled(TableRow)(({ theme }) => ({
+  '&.MuiTableRow-root:hover':{
+    backgroundColor: '#accad5' ,
+  },
+}));
+
+export default function ResultsScheduledDogs({dogList}) {
+
+
+  return (
+    <TableBody >
+      {dogList[0] && dogList[0].dog_id != undefined && dogList.map((dog) => (
+        <StyledTableRow key={dog.dog_id}>
+          <TableCell >{dog.name}</TableCell>
+          <TableCell >{dog.client_last_name}, {dog.client_first_name}</TableCell>
+          <TableCell >{dog.route_name}</TableCell>
+        </StyledTableRow>
+      ))}
+    </TableBody>
+  )
+}

--- a/src/components/AllPages/SearchResults/ResultsSearchDogs.jsx
+++ b/src/components/AllPages/SearchResults/ResultsSearchDogs.jsx
@@ -47,7 +47,8 @@ export default function ResultsSearchDogs({dogList, clientList, openModal, submi
       }).map((dog ) => (
         <StyledTableRow key={dog.dog_id}> 
           <TableCell onClick={()=>getDogDetails(dog)}>{dog.dog_name}</TableCell>
-          <TableCell onClick={()=>getDogDetails(dog)}>{dog.client_firstname} {dog.client_lastname}</TableCell>
+          <TableCell onClick={()=>getDogDetails(dog)}>{dog.client_lastname}, {dog.client_firstname}</TableCell>
+          <TableCell>{dog.route}</TableCell>
           { view==='desktop' ?
           <>
             <TableCell onClick={()=>getDogDetails(dog)}> {dog.days.join(', ').toUpperCase()} </TableCell>

--- a/src/components/Desktop/SplashPage/DogCount.jsx
+++ b/src/components/Desktop/SplashPage/DogCount.jsx
@@ -53,7 +53,6 @@ function DogCount() {
 
   const isWeekend = (date) => {
     const day = date.day();
-  
     return day === 0 || day === 6;
   };
 

--- a/src/components/Mobile/Search/MobileDogSearch.jsx
+++ b/src/components/Mobile/Search/MobileDogSearch.jsx
@@ -1,7 +1,7 @@
 import { useSelector, useDispatch } from "react-redux";
 import { useEffect, useState } from "react";
 import { useHistory, Link, useParams } from 'react-router-dom';
-
+import dayjs from 'dayjs';
 
 //MUI
 import { TableFooter, Paper, Stack, Table, TablePagination, TableSortLabel, Toolbar, TableBody, TableContainer, TableHead, TableRow, TableCell, Avatar, AppBar, Box, Divider, IconButton, List, ListItem, ListItemButton, ListItemText, ListItemSecondaryAction, Typography, Button, Grid, TextField } from '@mui/material';
@@ -13,27 +13,29 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import ResultsSearchDogs from '../../AllPages/SearchResults/ResultsSearchDogs';
 import ResultsAllDogs from '../../AllPages/SearchResults/ResultsAllDogs';
 import ResultsDogByDay from '../../AllPages/SearchResults/ResultsDogByDay';
+import ResultsScheduledDogs from '../../AllPages/SearchResults/ResultsScheduledDogs';
 
 export default function MobileDogSearch() {
 
   const clientList = useSelector(store => store.clientsReducer);
   const dogListToday = useSelector(store => store.scheduledDogs)
   const dispatch = useDispatch();
-  const history = useHistory();
-  const params = useParams();
+  let today = new Date().toISOString();
+
+  const [date, setDate] = useState(today);
   const [search, setSearch] = useState('');
   const [submittedSearch, setSubmittedSearch] = useState('');
-  const [weekSearch, setWeekSearch] = useState('')
-  // const [dogList, setDogList] = useState(clientList ? createDogList : [])
+  const [weekSearch, setWeekSearch] = useState('');
+  
+  const dogCount = dogListToday[0] && dogListToday[0].dog_id != undefined ? dogListToday.length : 0;
+
 
   useEffect(() => {
     dispatch({ type: 'FETCH_CLIENTS' });
     },[]
   );
 
-  let today = new Date().toISOString();
-
-  const [date, setDate] = useState(today);
+  
   const daysOfWeek = ['mon','tue','wed','thu','fri'];
   // console.log(daysOfWeek)
   const dogList = [...new Set(clientList.flatMap((client) =>
@@ -62,21 +64,19 @@ export default function MobileDogSearch() {
     setWeekSearch('');
     setSubmittedSearch('');
     setSearch('');
+    setDate(today);
   }
 
   const searchDogByDay = (day) => {
     setSearch('');
     setSubmittedSearch('');
     setWeekSearch(day);
+    setDate('');
   }
 
   const handleDateChange = (date) => {
     setDate(date);
     dispatch({ type: 'CHECK_DOG_SCHEDULES', payload: dayjs(date).format('YYYY-MM-DD') });
-  }
-
-  const searchDogsToday = () => {
-
   }
 
   const isWeekend = (date) => {
@@ -117,7 +117,8 @@ export default function MobileDogSearch() {
         <Button onClick={() => searchFunction()} variant="contained" color="secondary">Search</Button>
        }
       </Grid>
-      <Stack sx={{display:'flex', flexDirection:'row'}}>
+      <Stack sx={{display:'flex', flexDirection:'row', alignItems:'center'}}>
+      <Typography> <b>{dogCount}</b> Dogs scheduled </Typography>
         <LocalizationProvider dateAdapter={AdapterDayjs}>
             <DatePicker
               shouldDisableDate={isWeekend}
@@ -128,7 +129,6 @@ export default function MobileDogSearch() {
               }}
             />
         </LocalizationProvider>
-        <Button onClick={()=>searchDogsToday()}>Today</Button>  
       </Stack>
       <Stack sx={{display:'flex', flexDirection:'row'}}>
         {daysOfWeek.map((day,i) => (
@@ -155,13 +155,15 @@ export default function MobileDogSearch() {
                   <TableCell></TableCell>
                 </TableRow>
               </TableHead>
-            { submittedSearch && dogList.length > 0 ?
-              <ResultsSearchDogs dogList={dogList} submittedSearch={submittedSearch} />
-              : (weekSearch && dogList.length > 0  ) ?
-                <ResultsDogByDay dogList={dogList} weekSearch={weekSearch} />
-                : (dogList.length > 0 ) ?
-                <ResultsAllDogs dogList={dogList} />
-                : null
+            { date && dogListToday.length > 0 ?
+              <ResultsScheduledDogs dogList={dogListToday} />
+                : submittedSearch && dogList.length > 0 ?
+                  <ResultsSearchDogs dogList={dogList} submittedSearch={submittedSearch} />
+                  : (weekSearch && dogList.length > 0  ) ?
+                    <ResultsDogByDay dogList={dogList} weekSearch={weekSearch} />
+                    : (dogList.length > 0 ) ?
+                    <ResultsAllDogs dogList={dogList} />
+                    : null
             }
             </Table>
           </TableContainer >

--- a/src/components/Mobile/Search/MobileDogSearch.jsx
+++ b/src/components/Mobile/Search/MobileDogSearch.jsx
@@ -6,6 +6,9 @@ import { useHistory, Link, useParams } from 'react-router-dom';
 //MUI
 import { TableFooter, Paper, Stack, Table, TablePagination, TableSortLabel, Toolbar, TableBody, TableContainer, TableHead, TableRow, TableCell, Avatar, AppBar, Box, Divider, IconButton, List, ListItem, ListItemButton, ListItemText, ListItemSecondaryAction, Typography, Button, Grid, TextField } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 
 import ResultsSearchDogs from '../../AllPages/SearchResults/ResultsSearchDogs';
 import ResultsAllDogs from '../../AllPages/SearchResults/ResultsAllDogs';
@@ -14,6 +17,7 @@ import ResultsDogByDay from '../../AllPages/SearchResults/ResultsDogByDay';
 export default function MobileDogSearch() {
 
   const clientList = useSelector(store => store.clientsReducer);
+  const dogListToday = useSelector(store => store.scheduledDogs)
   const dispatch = useDispatch();
   const history = useHistory();
   const params = useParams();
@@ -27,6 +31,9 @@ export default function MobileDogSearch() {
     },[]
   );
 
+  let today = new Date().toISOString();
+
+  const [date, setDate] = useState(today);
   const daysOfWeek = ['mon','tue','wed','thu','fri'];
   // console.log(daysOfWeek)
   const dogList = [...new Set(clientList.flatMap((client) =>
@@ -36,6 +43,7 @@ export default function MobileDogSearch() {
       client_firstname: client.first_name,
       client_lastname: client.last_name,
       client_id: client.client_id,
+      route: client.route_name,
       mon: client.monday,
       tue: client.tuesday,
       wed: client.wednesday,
@@ -43,7 +51,8 @@ export default function MobileDogSearch() {
       fri: client.friday
     }))
   ))];
-    // console.log('doglist',dogList)
+
+  // console.log('doglist',dogList)
 
   const searchFunction = (event) => {
     setSubmittedSearch(search.toLowerCase())
@@ -60,6 +69,20 @@ export default function MobileDogSearch() {
     setSubmittedSearch('');
     setWeekSearch(day);
   }
+
+  const handleDateChange = (date) => {
+    setDate(date);
+    dispatch({ type: 'CHECK_DOG_SCHEDULES', payload: dayjs(date).format('YYYY-MM-DD') });
+  }
+
+  const searchDogsToday = () => {
+
+  }
+
+  const isWeekend = (date) => {
+    const day = date.day();
+    return day === 0 || day === 6;
+  };
 
   return (
     <Box className="mobile_container"
@@ -95,6 +118,19 @@ export default function MobileDogSearch() {
        }
       </Grid>
       <Stack sx={{display:'flex', flexDirection:'row'}}>
+        <LocalizationProvider dateAdapter={AdapterDayjs}>
+            <DatePicker
+              shouldDisableDate={isWeekend}
+              onChange={handleDateChange}
+              value={date}
+              renderInput={(params) => {
+                return <TextField {...params} sx={{ mt: 2 ,mx: 2, pb: 1, width: '30vw' }} />
+              }}
+            />
+        </LocalizationProvider>
+        <Button onClick={()=>searchDogsToday()}>Today</Button>  
+      </Stack>
+      <Stack sx={{display:'flex', flexDirection:'row'}}>
         {daysOfWeek.map((day,i) => (
           <Button key={i} onClick={()=>searchDogByDay(day)}>{day}</Button>
         ))}
@@ -115,7 +151,7 @@ export default function MobileDogSearch() {
                 <TableRow>
                   <TableCell sx={{fontWeight: '800'}}>Dog:</TableCell>
                   <TableCell sx={{fontWeight: '800'}}>Client:</TableCell>
-
+                  <TableCell sx={{fontWeight: '800'}}>Route:</TableCell>
                   <TableCell></TableCell>
                 </TableRow>
               </TableHead>

--- a/src/components/Mobile/Search/MobileDogSearch.jsx
+++ b/src/components/Mobile/Search/MobileDogSearch.jsx
@@ -26,12 +26,14 @@ export default function MobileDogSearch() {
   const [search, setSearch] = useState('');
   const [submittedSearch, setSubmittedSearch] = useState('');
   const [weekSearch, setWeekSearch] = useState('');
+  const [dogCount, setDogCount] = useState('')
   
-  const dogCount = dogListToday[0] && dogListToday[0].dog_id != undefined ? dogListToday.length : 0;
+  // let dogCount = dogListToday[0] && dogListToday[0].dog_id != undefined ? dogListToday.length : 0;
 
 
   useEffect(() => {
     dispatch({ type: 'FETCH_CLIENTS' });
+    setDogCount(dogListToday[0] && dogListToday[0].dog_id != undefined ? dogListToday.length : 0)
     },[]
   );
 
@@ -57,26 +59,30 @@ export default function MobileDogSearch() {
   // console.log('doglist',dogList)
 
   const searchFunction = (event) => {
-    setSubmittedSearch(search.toLowerCase())
+    setDate('');
+    setSubmittedSearch(search.toLowerCase());
+    setDogCount(undefined)
   }
 
   const clearResults = (event) => {
+    setDate('');
     setWeekSearch('');
     setSubmittedSearch('');
     setSearch('');
-    setDate(today);
   }
 
   const searchDogByDay = (day) => {
+    setDate('');
     setSearch('');
     setSubmittedSearch('');
     setWeekSearch(day);
-    setDate('');
+    setDogCount(undefined)
   }
 
   const handleDateChange = (date) => {
     setDate(date);
     dispatch({ type: 'CHECK_DOG_SCHEDULES', payload: dayjs(date).format('YYYY-MM-DD') });
+    setDogCount(dogListToday[0] && dogListToday[0].dog_id != undefined ? dogListToday.length : 0);
   }
 
   const isWeekend = (date) => {


### PR DESCRIPTION
Added list scheduled dog by day feature to MobileDogSearch.jsx.

code brought over from DogCount component:
dogListToday subscribes to scheduledDogs reducer;
state variable for date, as well as date getters/setters/handler functions
dayjs
MUI DatePicker

MobileDogSearch displays ResultsScheduledDogs component when state variable 'date' and dogListToday.length are defined.

MobileDogSearch is not a child variable of desktop comopnent DogSearch.

DogCount variable is list of dogListToday, and is a state variable. Searching for dogs via other pathways, ie 'search' bar or day-of-week buttons, sets dogCount to '' and causes component to return the appropriate ResultsSearch components.

unless I set a second dogcount state variable that set by dogList.length (suscribing to clientsReducer, and presumably duplciating some of the actual search logic that occurs in the Results components, dogCount only refers to dogs scheduled on a specific calendar day, not count of dogs on by a given week.
